### PR TITLE
Fix for considering ActionName attribute while resolving action

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,29 @@ CommonAssemblyInfo.cs
 /Build/CodeCoverage/
 NCover3.lic
 FluentSecurity.1.1.dotCover
+
+#OS junk files
+[Tt]humbs.db
+*.DS_Store
+
+#Visual Studio files
+*.[Oo]bj
+*.pdb
+*.user
+*.suo
+*.[Cc]ache
+obj/
+[Bb]in
+[Dd]ebug*/
+[Rr]elease*/
+
+#Tooling
+_ReSharper*/
+*.resharper
+[Tt]est[Rr]esult*
+
+#Project files
+[Bb]uild/[Oo]utput
+[Bb]uild/[Rr]eports
+[Bb]uild/[Pp]ackages
+[Ll]ogs/

--- a/FluentSecurity.Specification/ExtensionsSpecs.cs
+++ b/FluentSecurity.Specification/ExtensionsSpecs.cs
@@ -181,6 +181,19 @@ namespace FluentSecurity.Specification
 			// Assert
 			Assert.That(name, Is.EqualTo("InstanceMethodCallExpression"));
 		}
+		
+		[Test]
+		public void Should_consider_ActionNameAttibute()
+		{
+			// Arrange
+			Expression<Func<TestController, object>> expression = x => x.ActualAction();
+
+			// Act
+			var name = expression.GetActionName();
+
+			// Assert
+			Assert.That(name, Is.EqualTo("AliasAction"));
+		}
 
 		private class TestController
 		{
@@ -190,6 +203,12 @@ namespace FluentSecurity.Specification
 			}
 
 			public ActionResult InstanceMethodCallExpression()
+			{
+				return new EmptyResult();
+			}
+			
+			[ActionName("AliasAction")]
+			public ActionResult ActualAction()
 			{
 				return new EmptyResult();
 			}

--- a/FluentSecurity.Specification/TestData/BlogController.cs
+++ b/FluentSecurity.Specification/TestData/BlogController.cs
@@ -43,7 +43,7 @@ namespace FluentSecurity.Specification.TestData
 		{
 			return Json(new {});
 		}
-
+		
 		private void PrivateMethodThatDoesNothing()
 		{
 		}

--- a/FluentSecurity.TestHelper.Specification/ExpectationExpressionSpec.cs
+++ b/FluentSecurity.TestHelper.Specification/ExpectationExpressionSpec.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Linq;
+using FluentSecurity.Policy;
 using FluentSecurity.TestHelper.Expectations;
 using FluentSecurity.TestHelper.Specification.TestData;
 using NUnit.Framework;
@@ -116,6 +117,25 @@ namespace FluentSecurity.TestHelper.Specification
 
 			// Assert
 			Assert.That(_expectationExpression.Expectations.Count(), Is.EqualTo(2));
+		}
+	}
+	
+	[TestFixture]
+	[Category("ExpectationExpressionSpec")]
+	public class When_creating_an_expectation_expression_for_SampleController_AliasedAction
+	{
+		private ExpectationExpression<SampleController> _expectationExpression;
+
+		[SetUp]
+		public void SetUp()
+		{
+			_expectationExpression = new ExpectationExpression<SampleController>(x => x.ActualAction());
+		}
+
+		[Test]
+		public void Should_resolve_actual_action_to_aliased_action()
+		{
+			Assert.That(_expectationExpression.Action, Is.EqualTo("AliasedAction"));
 		}
 	}
 }

--- a/FluentSecurity.TestHelper.Specification/ExpectationGroupBuilderSpec.cs
+++ b/FluentSecurity.TestHelper.Specification/ExpectationGroupBuilderSpec.cs
@@ -96,7 +96,7 @@ namespace FluentSecurity.TestHelper.Specification
 		}
 
 		[Test]
-		public void Should_have_return_8_expectation_groups_for_2_expressions()
+		public void Should_have_return_9_expectation_groups_for_2_expressions()
 		{
 			// Arrange
 			var expecatationExpressions = new List<ExpectationExpression>
@@ -110,7 +110,7 @@ namespace FluentSecurity.TestHelper.Specification
 			var expectationGroups = expecationBuilder.Build(expecatationExpressions);
 
 			// Assert
-			Assert.That(expectationGroups.Count(), Is.EqualTo(8));
+			Assert.That(expectationGroups.Count(), Is.EqualTo(9));
 		}
 	}
 }

--- a/FluentSecurity.TestHelper.Specification/SecurityConfigurationExtensionsSpec.cs
+++ b/FluentSecurity.TestHelper.Specification/SecurityConfigurationExtensionsSpec.cs
@@ -57,6 +57,19 @@ namespace FluentSecurity.TestHelper.Specification
 
 			Assert.That(results.All(x => x.ExpectationsMet), results.ErrorMessages());
 		}
+		
+		[Test]
+		public void Should_verify_expectations_for_aliased_action()
+		{
+			SecurityConfigurator.Configure(configuration  => 
+               {
+				configuration.For<SampleController>(a => a.ActualAction()).DenyAnonymousAccess();
+               });
+			var policyExpectations = new PolicyExpectations();
+			policyExpectations.For<SampleController>(a => a.ActualAction()).Has<DenyAnonymousAccessPolicy>();
+			var results = policyExpectations.VerifyAll(SecurityConfiguration.Current);
+			Assert.That(results.Valid(), results.ErrorMessages());
+		}
 	}
 
 	[TestFixture]

--- a/FluentSecurity.TestHelper.Specification/TestData/SampleController.cs
+++ b/FluentSecurity.TestHelper.Specification/TestData/SampleController.cs
@@ -23,5 +23,11 @@ namespace FluentSecurity.TestHelper.Specification.TestData
 		{
 			return null;
 		}
+		
+		[ActionName("AliasedAction")]
+		public ActionResult ActualAction()
+		{
+			return null;
+		}
 	}
 }

--- a/FluentSecurity/ConfigurationExpression.cs
+++ b/FluentSecurity/ConfigurationExpression.cs
@@ -105,18 +105,18 @@ namespace FluentSecurity
 
 		private IConventionPolicyContainer CreateConventionPolicyContainerFor(IEnumerable<Type> controllerTypes, By defaultCacheLevel = By.Policy)
 		{
-			var policyContainers = new List<IPolicyContainer>();
-			foreach (var controllerType in controllerTypes)
-			{
+				var policyContainers = new List<IPolicyContainer>();
+				foreach (var controllerType in controllerTypes)
+				{
 				var controllerName = controllerType.GetControllerName();
 				var actionMethods = controllerType.GetActionMethods();
-
+				
 				policyContainers.AddRange(
-					actionMethods.Select(actionMethod => AddPolicyContainerFor(controllerName, actionMethod.Name))
-					);
-			}
-
-			return new ConventionPolicyContainer(policyContainers, defaultCacheLevel);
+				actionMethods.Select(actionMethod => AddPolicyContainerFor(controllerName, actionMethod.Name))
+				);
+				}
+				
+				return new ConventionPolicyContainer(policyContainers, defaultCacheLevel);
 		}
 
 		public void GetAuthenticationStatusFrom(Func<bool> isAuthenticatedFunction)

--- a/FluentSecurity/Extensions.cs
+++ b/FluentSecurity/Extensions.cs
@@ -89,8 +89,22 @@ namespace FluentSecurity
 		public static string GetActionName(this LambdaExpression actionExpression)
 		{
 			var expression = (MethodCallExpression)(actionExpression.Body is UnaryExpression ? ((UnaryExpression)actionExpression.Body).Operand : actionExpression.Body);
-			return expression.Method.Name;
+            return expression.Method.GetActionName();
 		}
+
+        private static Type ActionNameAttributeType = typeof(ActionNameAttribute);
+
+        /// <summary>
+        /// Gets action name for the specified action method considering ActionName attribute
+        /// </summary>
+        public static String GetActionName(this MethodInfo actionMethod)
+        {
+            if (Attribute.IsDefined(actionMethod, ActionNameAttributeType))
+            {
+                return (Attribute.GetCustomAttribute(actionMethod, typeof(ActionNameAttribute)) as ActionNameAttribute).Name;
+            }
+            return actionMethod.Name;
+        }
 
 		/// <summary>
 		/// Gets the actual type of the ISecurityPolicy. Takes care of checking for lazy policies.


### PR DESCRIPTION
Applied the following changes/fixes:
- Added gitignore file.
- Added GetActionName extension  method for MethodInfo class (file: FluentSecurity/Extensions.cs) to consider the ActionName attribute of the action method.
