### PR TITLE
Changed GetActionName method to use the static ActionNameAttributeType

### DIFF
--- a/FluentSecurity/Extensions.cs
+++ b/FluentSecurity/Extensions.cs
@@ -50,7 +50,7 @@ namespace FluentSecurity
 		{
 			if (Attribute.IsDefined(actionMethod, ActionNameAttributeType))
 			{
-				var actionNameAttribute = (ActionNameAttribute) Attribute.GetCustomAttribute(actionMethod, typeof (ActionNameAttribute));
+				var actionNameAttribute = (ActionNameAttribute) Attribute.GetCustomAttribute(actionMethod, ActionNameAttributeType);
 				return actionNameAttribute.Name;
 			}
 			return actionMethod.Name;


### PR DESCRIPTION
Changed:

`var actionNameAttribute = (ActionNameAttribute) Attribute.GetCustomAttribute(actionMethod, typeof (ActionNameAttribute));`

to

`var actionNameAttribute = (ActionNameAttribute) Attribute.GetCustomAttribute(actionMethod, ActionNameAttributeType);`

of FluentSecurity.Extensions.cs
