### PR TITLE
Changes for handling void actions configuration

### DIFF
--- a/FluentSecurity.Specification/ConfigurationExpressionSpec.cs
+++ b/FluentSecurity.Specification/ConfigurationExpressionSpec.cs
@@ -143,6 +143,109 @@ namespace FluentSecurity.Specification
 
 	[TestFixture]
 	[Category("ConfigurationExpressionSpec")]
+	public class When_adding_a_policycontainter_for_void_action
+	{
+		[Test]
+		public void Should_have_policycontainer_for_controller_with_void_action()
+		{
+			// Arrange
+			var configurationExpression = new RootConfiguration();
+			configurationExpression.GetAuthenticationStatusFrom(StaticHelper.IsAuthenticatedReturnsFalse);
+
+			// Act
+			configurationExpression.For<ParentVoidActionController>(x => x.VoidAction());
+
+			// Assert
+			Assert.That(configurationExpression.Runtime.PolicyContainers.Count(), Is.EqualTo(1));
+		}
+
+		[Test]
+		public void Should_have_policycontainer_for_void_action_from_parent_controller()
+		{
+			// Arrange
+			var configurationExpression = new RootConfiguration();
+			configurationExpression.GetAuthenticationStatusFrom(StaticHelper.IsAuthenticatedReturnsFalse);
+
+			// Act
+			configurationExpression.For<ChildVoidActionController>(x => x.VoidAction());
+
+			// Assert
+			Assert.That(configurationExpression.Runtime.PolicyContainers.Count(), Is.EqualTo(1));
+		}
+
+		private class ParentVoidActionController : Controller
+		{
+			public void VoidAction()
+			{
+				
+			}
+		}
+
+		private class ChildVoidActionController:ParentVoidActionController
+		{
+			
+		}
+	}
+
+	[Category("ConfigurationExpressionSpec")]
+	public class When_adding_a_policycontainter_using_ByController_convention
+	{
+		[Test]
+		public void Should_have_policycontainer_for_all_actions_including_void_actions()
+		{
+			// Arrange
+			var configurationExpression = new RootConfiguration();
+			configurationExpression.GetAuthenticationStatusFrom(StaticHelper.IsAuthenticatedReturnsFalse);
+
+			// Act
+			configurationExpression.For<ParentVoidActionController>();
+
+			// Assert
+			Assert.That(configurationExpression.Runtime.PolicyContainers.Count(), Is.EqualTo(2));
+		}
+
+		public void Should_have_policycontainer_for_all_actions_including_inherited_void_actions()
+		{
+			// Arrange
+			var configurationExpression = new RootConfiguration();
+			configurationExpression.GetAuthenticationStatusFrom(StaticHelper.IsAuthenticatedReturnsFalse);
+
+			// Act
+			configurationExpression.For<ChildVoidActionController>();
+
+			// Assert
+			Assert.That(configurationExpression.Runtime.PolicyContainers.Count(), Is.EqualTo(2));
+		}
+
+		private class ParentVoidActionController : Controller
+		{
+			public void VoidAction()
+			{
+
+			}
+
+			public ActionResult DummyAction()
+			{
+				return new EmptyResult();
+			}
+		}
+
+		private class ChildVoidActionController : ParentVoidActionController
+		{
+			public void VoidAction()
+			{
+
+			}
+
+			public ActionResult DummyAction()
+			{
+				return new EmptyResult();
+			}
+		}
+	}
+
+	[TestFixture]
+	[Category("ConfigurationExpressionSpec")]
 	public class When_adding_a_policycontainter_for_Blog_Index_and_AddPost
 	{
 		[Test]

--- a/FluentSecurity/ConfigurationExpression.cs
+++ b/FluentSecurity/ConfigurationExpression.cs
@@ -39,6 +39,14 @@ namespace FluentSecurity
 			return AddPolicyContainerFor(controllerName, actionName);
 		}
 
+		public IPolicyContainerConfiguration For<TController>(Expression<Action<TController>> actionExpression) where TController : Controller
+		{
+			var controllerName = typeof(TController).GetControllerName();
+			var actionName = actionExpression.GetActionName();
+
+			return AddPolicyContainerFor(controllerName, actionName);
+		}
+
 		public IPolicyContainerConfiguration For<TController>() where TController : Controller
 		{
 			var controllerType = typeof(TController);

--- a/FluentSecurity/Extensions.cs
+++ b/FluentSecurity/Extensions.cs
@@ -80,11 +80,30 @@ namespace FluentSecurity
 			return controllerType
 				.GetMethods(
 					BindingFlags.Public |
-					BindingFlags.Instance
+					BindingFlags.Instance 
 				)
-				.Where(methodInfo => methodInfo.ReturnType.IsControllerActionReturnType())
+				.Where(IsValidActionMethod)
 				.Where(action => actionFilter.Invoke(new ControllerActionInfo(controllerType, action)))
 				.ToList();
+		}
+
+		internal static bool IsValidActionMethod(this MethodInfo methodInfo)
+		{
+			return methodInfo.ReturnType.IsControllerActionReturnType() &&
+			       !methodInfo.IsSpecialName && !methodInfo.IsDeclaredBy<Controller>();
+		}
+
+		/// <summary>
+		/// Returns true if the passed method is declared by the type T.
+		/// </summary>
+		/// <param name="methodInfo"></param>
+		/// <returns></returns>
+		//(Chandu) The method below is to simulate the way System.Web.Mvc.ActionMethodSelector.IsValidActionMethod identifies methods of a controller as valid actions
+		internal static bool IsDeclaredBy<T>(this MethodInfo methodInfo)
+		{
+			var passedType = typeof (T);
+			var declaringType = methodInfo.GetBaseDefinition().DeclaringType;
+			return declaringType != null && declaringType.IsAssignableFrom(passedType);
 		}
 
 		/// <summary>
@@ -94,7 +113,12 @@ namespace FluentSecurity
 		/// <returns></returns>
 		internal static bool IsControllerActionReturnType(this Type returnType)
 		{
-			return typeof (ActionResult).IsAssignableFrom(returnType) || typeof (Task<ActionResult>).IsAssignableFromGenericType(returnType);
+			return 
+				(
+					typeof (ActionResult).IsAssignableFrom(returnType) || 
+					typeof (Task<ActionResult>).IsAssignableFromGenericType(returnType) ||
+					typeof(void).IsAssignableFrom(returnType)
+					);
 		}
 
 		/// <summary>


### PR DESCRIPTION
Includes changes to handle configuring void actions when
- configured using For<TController>() by default
- configured explicitly like For<TController>(a => a.SomeAction()) 

Had to simulate some code as implemented by System.Web.Mvc.ActionMethodSelector.IsValidActionMethod to handle all scenarios

Addresses #57 
