### PR TITLE
Inherit AuthorizeAttribute so 3rd parties can identify FluentSecurity as an authorization component

### DIFF
--- a/FluentSecurity/HandleSecurityAttribute.cs
+++ b/FluentSecurity/HandleSecurityAttribute.cs
@@ -1,11 +1,12 @@
 using System;
+using System.ComponentModel;
 using System.Web.Mvc;
 using FluentSecurity.ServiceLocation;
 
 namespace FluentSecurity
 {
 	[AttributeUsage(AttributeTargets.Class, AllowMultiple = false, Inherited = true)]
-	public class HandleSecurityAttribute : Attribute, IAuthorizationFilter
+	public class HandleSecurityAttribute : AuthorizeAttribute, IAuthorizationFilter
 	{
 		internal ISecurityHandler Handler { get; private set; }
 
@@ -16,7 +17,7 @@ namespace FluentSecurity
 			Handler = securityHandler;
 		}
 
-		public void OnAuthorization(AuthorizationContext filterContext)
+		public override void OnAuthorization(AuthorizationContext filterContext)
 		{
 			var actionName = filterContext.ActionDescriptor.ActionName;
 			var controllerName = filterContext.ActionDescriptor.ControllerDescriptor.ControllerType.FullName;
@@ -27,5 +28,20 @@ namespace FluentSecurity
 			var overrideResult = Handler.HandleSecurityFor(controllerName, actionName, securityContext);
 			if (overrideResult != null) filterContext.Result = overrideResult;
 		}
+
+		[Obsolete("Not applicable in this class.")]
+		[DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+		[Browsable(false), EditorBrowsable(EditorBrowsableState.Never)]
+		new public string Roles { get; set; }
+
+		[Obsolete("Not applicable in this class.")]
+		[DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+		[Browsable(false), EditorBrowsable(EditorBrowsableState.Never)]
+		new public string Users { get; set; }
+
+		[Obsolete("Not applicable in this class.")]
+		[DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+		[Browsable(false), EditorBrowsable(EditorBrowsableState.Never)]
+		new public int Order { get; set; }
 	}
 }


### PR DESCRIPTION
As mentioned in #72, MvcSiteMapProvider can automatically pick up the authorization settings from FluentSecurity if it inherits AuthorizeAttribute.

Per [this post](http://weblogs.asp.net/rashid/archive/2009/09/06/asp-net-mvc-and-authorization-and-monkey-patching.aspx), there are many built-in types in the MVC framework (and potentially by 3rd parties) that implement IAuthorizationFilter (including Controller), and most of these types do not provide any authorization capability. The only positive way to identify that a component is for MVC authorization is if it inherits AuthorizeAttribute. Since that is _exactly_ what FluentSecurity does, it should inherit AuthorizeAttribute.

Although, admittedly on your side of the fence this looks a little like a hack because of the hidden properties, this fix creates the ideal scenario.
1. If you install FluentSecurity, it will work.
2. If you install MvcSiteMapProvider, it will work.
3. If you install FluentSecurity and MvcSiteMapProvider, they will automatically interact.
4. There are no dependencies required between the two libraries.
5. There are no special cases in either library.
6. There is no special configuration required for either library to make them interact.
7. Other 3rd party components can potentially pick up FluentSecurity automatically, as well.

Do note that I put the property hiding in a separate commit in case you want to do it another way. Also note that the Order, Roles, and Users properties are only hidden if you access the library from another solution, but they are visible within the FluentSecuirty solution. If desired, you could also hide the protected members of AuthorizeAttribute so they aren't visible to inheritors of HandleSecurityAttribute.

This change is completely backward compatible with the current implementation.

I tested it with MvcSiteMapProvider and it is working. I also verified the build script is working.
