### PR TITLE
Ignore NonAction actions on controller.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,6 @@ _ReSharper*/
 NCover*.lic
 *.*.dotCover
 *.DotSettings
+
+#SharpDevelop files
+*.sdsettings

--- a/FluentSecurity.Specification/ConfigurationExpressionSpec.cs
+++ b/FluentSecurity.Specification/ConfigurationExpressionSpec.cs
@@ -370,6 +370,36 @@ namespace FluentSecurity.Specification
 
 	[TestFixture]
 	[Category("ConfigurationExpressionSpec")]
+	public class When_adding_a_conventionpolicycontainter_for_controller_with_nonaction_actions
+	{
+	[Test]
+		public void Should_not_have_policycontainer_for_actions_marked_as_NonAction()
+		{
+		// Arrange
+			var configurationExpression = new RootConfiguration();
+			configurationExpression.GetAuthenticationStatusFrom(StaticHelper.IsAuthenticatedReturnsFalse);
+
+			// Act
+			configurationExpression.For<NonActionController>();
+
+			// Assert
+			var policyContainers = configurationExpression.Runtime.PolicyContainers;
+
+			Assert.That(configurationExpression.Runtime.PolicyContainers.Count(), Is.EqualTo(0));
+		}
+		
+		private class NonActionController : Controller
+		{
+			[NonAction]
+			public ActionResult SomeAction()
+			{
+				return null;
+			}
+		}
+	}
+	
+	[TestFixture]
+	[Category("ConfigurationExpressionSpec")]
 	public class When_adding_a_conventionpolicycontainter_for_controller_with_aliased_action
 	{
 		[Test]

--- a/FluentSecurity/Extensions.cs
+++ b/FluentSecurity/Extensions.cs
@@ -92,7 +92,18 @@ namespace FluentSecurity
 			return
 				methodInfo.ReturnType.IsControllerActionReturnType() &&
 				!methodInfo.IsSpecialName &&
-				!methodInfo.IsDeclaredBy<Controller>();
+				!methodInfo.IsDeclaredBy<Controller>() &&
+				!methodInfo.HasAttribute<NonActionAttribute>();
+		}
+		
+		/// <summary>
+		/// Returns true if the passed method has the attribute of type TAttribute
+		/// </summary>
+		/// <param name="methodInfo">MethodInfo of the method to verify</param>
+		/// <returns></returns>
+		internal static bool HasAttribute<TAttribute>(this MethodInfo methodInfo) where TAttribute:Attribute
+		{
+			return methodInfo.GetCustomAttributes(typeof(TAttribute), false).Any();
 		}
 
 		/// <summary>


### PR DESCRIPTION
Added code to ignore action methods with [NonAction] attribute while picking action methods for policy construction
